### PR TITLE
Regenerated API clients with Kiota

### DIFF
--- a/get-started/quickstart/typescript/client/posts/postsRequestBuilder.ts
+++ b/get-started/quickstart/typescript/client/posts/postsRequestBuilder.ts
@@ -5,8 +5,8 @@ import {serializePost} from '../models/serializePost';
 import {PostItemRequestBuilder} from './item/postItemRequestBuilder';
 import {PostsRequestBuilderGetRequestConfiguration} from './postsRequestBuilderGetRequestConfiguration';
 import {PostsRequestBuilderPostRequestConfiguration} from './postsRequestBuilderPostRequestConfiguration';
-import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 import {BaseRequestBuilder, HttpMethod, RequestInformation, getPathParameters} from '@microsoft/kiota-abstractions';
+import type {Parsable, ParsableFactory, RequestAdapter, RequestOption} from '@microsoft/kiota-abstractions';
 
 /**
  * Builds and executes requests for operations under /posts


### PR DESCRIPTION
@baywet any idea why this line keeps jumping around? This is the third day in a row that the generation has moved this one particular line - it keeps jumping from above to below the `import {BaseRequestBuilder, HttpMethod...` line, and back again.

Closes #3344 