### PR TITLE
ci: adds missing gradle dependencies caching to CI

### DIFF
--- a/.github/workflows/get-started-java.yml
+++ b/.github/workflows/get-started-java.yml
@@ -33,6 +33,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
+        cache: gradle
     - name: Make gradlew executable
       run: chmod +x ./gradlew
     - name: Setup Gradle
@@ -55,6 +56,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
+        cache: gradle
     - name: Make gradlew executable
       run: chmod +x ./gradlew
     - name: Setup Gradle


### PR DESCRIPTION
related https://www.sonatype.com/blog/maven-central-and-the-tragedy-of-the-commons